### PR TITLE
Bugfix: removed wrong entry in JSONKeyPathsByPropertyKey (introduced in ...

### DIFF
--- a/AJSITunesAPI/AJSITunesResult.m
+++ b/AJSITunesAPI/AJSITunesResult.m
@@ -113,7 +113,7 @@ NSString *const AJSITunesAttributeTvSeasonTerm = @"tvSeasonTerm";
               @"duration" : @"trackTimeMillis",
               @"releaseDate" : @"releaseDate",
               @"imageURLString" : @"artworkUrl100",
-              @"smallImageURLString" : @"artworkUrl60"};
+              };
 }
 
 


### PR DESCRIPTION
...last commit)

Sorry, I made a little mistake in my last commit. I don't know why nothing happened before, but after I updated to the recent AFNetworking today, this caused a bug.
